### PR TITLE
Use `innmind/specification` 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Requires `innmind/specification:~4.0`
+
 ## 2.17.0 - 2024-05-29
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "~8.2",
         "innmind/immutable": "~4.0|~5.0",
         "innmind/url": "~4.0",
-        "innmind/specification": "^3.0.1",
+        "innmind/specification": "~4.0",
         "psr/log": "~3.0"
     },
     "autoload": {


### PR DESCRIPTION
## Problem

The version 3 allowed to express with `Sign` queries that could also be expressed through composition.

This lead to an incomplete translation from specification to SQL query. For example if someone makes a specification with the sign `equality` and the value `null` it fails.

## Solution

Use `innmind/specification` 4

## Note

This will require to release this as a new major update since this is a BC break.