### PR TITLE
Fix memory assertion

### DIFF
--- a/blackbox.php
+++ b/blackbox.php
@@ -3,8 +3,6 @@ declare(strict_types = 1);
 
 require 'vendor/autoload.php';
 
-\ini_set('memory_limit', '-1');
-
 use Innmind\BlackBox\{
     Application,
     Runner\Load,
@@ -12,6 +10,7 @@ use Innmind\BlackBox\{
 };
 
 Application::new($argv)
+    ->disableMemoryLimit()
     ->codeCoverage(
         CodeCoverage::of(
             __DIR__.'/src/',


### PR DESCRIPTION
## Problem

The lazy select test manually verify the memory consumption via `memory_get_peak_usage()` but this can produce false positive due to other proofs being run before this one setting the peak usage way to high.

## Solution

Use the builtin BlackBox memory assertion.