### PR TITLE
Fix applying a moreThanOrEqual or lessThanOrEqual when the columns are different

### DIFF
--- a/proofs/query/where.php
+++ b/proofs/query/where.php
@@ -133,7 +133,7 @@ return static function() {
             $where = Where::of($lessThan->or($equal));
 
             $assert->same(
-                "WHERE ({$column1->name()->sql(Driver::mysql)} < ? OR {{$column2->name()->sql(Driver::mysql)} = ?})",
+                "WHERE ({$column1->name()->sql(Driver::mysql)} < ? OR {$column2->name()->sql(Driver::mysql)} = ?)",
                 $where->sql(Driver::mysql),
             );
             $assert->count(2, $where->parameters());

--- a/proofs/query/where.php
+++ b/proofs/query/where.php
@@ -113,6 +113,42 @@ return static function() {
     );
 
     yield proof(
+        'Where less than or equal comparator on different columns',
+        given(
+            Column::any(),
+            Column::any(),
+            Set\Strings::any(),
+        ),
+        static function($assert, $column1, $column2, $value) {
+            $lessThan = Property::of(
+                $column1->name()->toString(),
+                Sign::lessThan,
+                $value,
+            );
+            $equal = Property::of(
+                $column2->name()->toString(),
+                Sign::equality,
+                $value,
+            );
+            $where = Where::of($lessThan->or($equal));
+
+            $assert->same(
+                "WHERE ({$column1->name()->sql(Driver::mysql)} < ? OR {{$column2->name()->sql(Driver::mysql)} = ?})",
+                $where->sql(Driver::mysql),
+            );
+            $assert->count(2, $where->parameters());
+            $assert->same($value, $where->parameters()->first()->match(
+                static fn($parameter) => $parameter->value(),
+                static fn() => null,
+            ));
+            $assert->same($value, $where->parameters()->last()->match(
+                static fn($parameter) => $parameter->value(),
+                static fn() => null,
+            ));
+        },
+    );
+
+    yield proof(
         'Where more than comparator',
         given(
             Column::any(),
@@ -163,6 +199,42 @@ return static function() {
             );
             $assert->count(1, $where->parameters());
             $assert->same($value, $where->parameters()->first()->match(
+                static fn($parameter) => $parameter->value(),
+                static fn() => null,
+            ));
+        },
+    );
+
+    yield proof(
+        'Where more than or equal comparator on different columns',
+        given(
+            Column::any(),
+            Column::any(),
+            Set\Strings::any(),
+        ),
+        static function($assert, $column1, $column2, $value) {
+            $moreThan = Property::of(
+                $column1->name()->toString(),
+                Sign::moreThan,
+                $value,
+            );
+            $equal = Property::of(
+                $column2->name()->toString(),
+                Sign::equality,
+                $value,
+            );
+            $where = Where::of($moreThan->or($equal));
+
+            $assert->same(
+                "WHERE ({$column1->name()->sql(Driver::mysql)} > ? OR {$column2->name()->sql(Driver::mysql)} = ?)",
+                $where->sql(Driver::mysql),
+            );
+            $assert->count(2, $where->parameters());
+            $assert->same($value, $where->parameters()->first()->match(
+                static fn($parameter) => $parameter->value(),
+                static fn() => null,
+            ));
+            $assert->same($value, $where->parameters()->last()->match(
                 static fn($parameter) => $parameter->value(),
                 static fn() => null,
             ));

--- a/src/Query/Where.php
+++ b/src/Query/Where.php
@@ -250,6 +250,7 @@ final class Where
             $specification->left()->sign() === Sign::moreThan &&
             $specification->right() instanceof Comparator &&
             $specification->right()->sign() === Sign::equality &&
+            $specification->left()->property() === $specification->right()->property() &&
             $specification->left()->value() === $specification->right()->value()
         ) {
             return $this->findComparatorParameters(
@@ -265,6 +266,7 @@ final class Where
             $specification->left()->sign() === Sign::lessThan &&
             $specification->right() instanceof Comparator &&
             $specification->right()->sign() === Sign::equality &&
+            $specification->left()->property() === $specification->right()->property() &&
             $specification->left()->value() === $specification->right()->value()
         ) {
             return $this->findComparatorParameters(

--- a/src/Query/Where.php
+++ b/src/Query/Where.php
@@ -145,6 +145,7 @@ final class Where
             $specification->left()->sign() === Sign::moreThan &&
             $specification->right() instanceof Comparator &&
             $specification->right()->sign() === Sign::equality &&
+            $specification->left()->property() === $specification->right()->property() &&
             $specification->left()->value() === $specification->right()->value()
         ) {
             return \sprintf(
@@ -159,6 +160,7 @@ final class Where
             $specification->left()->sign() === Sign::lessThan &&
             $specification->right() instanceof Comparator &&
             $specification->right()->sign() === Sign::equality &&
+            $specification->left()->property() === $specification->right()->property() &&
             $specification->left()->value() === $specification->right()->value()
         ) {
             return \sprintf(


### PR DESCRIPTION
## Problem

When trying to optimise the `lessThanOrEqual` or `moreThanOrEqual` it's applying the optimisation even if the 2 columns of the composite are different resulting in invalid results.

## Solution

Check the columns are the same