### PR TITLE
Fix capabilities for orm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /composer.lock
 /vendor
 /.cache
-/tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Removed
+
+- `Formal\AccessLayer\Driver::sqlite`
+
 ## 3.0.0 - 2024-07-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `Formal\AccessLayer\Driver::sqlite`
 
+### Fixed
+
+- Support for aliased table names when using `Formal\AccessLayer\Query\Delete`
+
 ## 3.0.0 - 2024-07-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `Formal\AccessLayer\Query\Delete::join()`
+
 ### Removed
 
 - `Formal\AccessLayer\Driver::sqlite`

--- a/documentation/connections/pdo.md
+++ b/documentation/connections/pdo.md
@@ -24,14 +24,6 @@ To build an instance of it you only need the dsn to your database:
     );
     ```
 
-=== "SQLite"
-    ```php
-    use Formal\AccessLayer\Connection\PDO;
-    use Innmind\Url\Url;
-
-    $connection = PDO::of(Url::of('sqlite:///path/to/database/file.sq3'));
-    ```
-
 When executing a [query](../queries/sql.md) through this connection it will return a [deferred `Sequence`](http://innmind.github.io/Immutable/structures/sequence/#defer) of rows. This means that the rows returned from the database are only loaded once you iterate over the sequence. (Queries with the named constructor `::onDemand()` will return a lazy `Sequence`).
 
 !!! note ""

--- a/properties/Connection.php
+++ b/properties/Connection.php
@@ -74,6 +74,7 @@ final class Connection
             Connection\Update::class,
             Connection\UpdateSpecificRow::class,
             Connection\Delete::class,
+            Connection\DeleteWithAlias::class,
             Connection\DeleteSpecificRow::class,
         ];
     }

--- a/properties/Connection/DeleteSpecificRow.php
+++ b/properties/Connection/DeleteSpecificRow.php
@@ -71,9 +71,9 @@ final class DeleteSpecificRow implements Property
             ]),
         )));
 
-        $delete = Query\Delete::from(Table\Name::of('test'))->where(
+        $delete = Query\Delete::from(Table\Name::of('test')->as('alias'))->where(
             Comparator\Property::of(
-                'id',
+                'alias.id',
                 Sign::equality,
                 $this->uuid1,
             ),

--- a/properties/Connection/DeleteWithAlias.php
+++ b/properties/Connection/DeleteWithAlias.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types = 1);
+
+namespace Properties\Formal\AccessLayer\Connection;
+
+use Formal\AccessLayer\{
+    Query\SQL,
+    Query,
+    Table,
+    Row,
+    Connection,
+};
+use Innmind\BlackBox\{
+    Property,
+    Set,
+    Runner\Assert,
+};
+
+/**
+ * @implements Property<Connection>
+ */
+final class DeleteWithAlias implements Property
+{
+    private string $uuid;
+
+    public function __construct(string $uuid)
+    {
+        $this->uuid = $uuid;
+    }
+
+    public static function any(): Set
+    {
+        return Set\Uuid::any()->map(static fn($uuid) => new self($uuid));
+    }
+
+    public function applicableTo(object $connection): bool
+    {
+        return true;
+    }
+
+    public function ensureHeldBy(Assert $assert, object $connection): object
+    {
+        $select = SQL::of('SELECT * FROM test');
+        $connection(Query\Insert::into(
+            Table\Name::of('test'),
+            Row::of([
+                'id' => $this->uuid,
+                'username' => 'foo',
+                'registerNumber' => 42,
+            ]),
+        ));
+
+        $sequence = $connection(Query\Delete::from(
+            Table\Name::of('test')->as('alias'),
+        ));
+
+        $assert->count(0, $sequence);
+
+        $rows = $connection($select);
+
+        $assert->count(0, $rows);
+
+        return $connection;
+    }
+}

--- a/src/Connection/PDO.php
+++ b/src/Connection/PDO.php
@@ -42,7 +42,6 @@ final class PDO implements Connection
         }
 
         $this->driver = match ($dsn->scheme()->toString()) {
-            'sqlite' => Driver::sqlite,
             'mysql' => Driver::mysql,
             'pgsql' => Driver::postgres,
         };
@@ -59,26 +58,16 @@ final class PDO implements Connection
             }
         }
 
-        $pdoDsn = match ($this->driver) {
-            Driver::sqlite => \sprintf(
-                'sqlite:%s',
-                $dsn->path()->toString(),
-            ),
-            default => \sprintf(
-                '%s:host=%s;port=%s;dbname=%s%s',
-                $dsn->scheme()->toString(),
-                $dsn->authority()->host()->toString(),
-                $dsn->authority()->port()->toString(),
-                \substr($dsn->path()->toString(), 1), // substring to remove leading '/'
-                $charset,
-            ),
-        };
+        $pdoDsn = \sprintf(
+            '%s:host=%s;port=%s;dbname=%s%s',
+            $dsn->scheme()->toString(),
+            $dsn->authority()->host()->toString(),
+            $dsn->authority()->port()->toString(),
+            \substr($dsn->path()->toString(), 1), // substring to remove leading '/'
+            $charset,
+        );
 
         $this->pdo = new \PDO($pdoDsn, $user, $password, $options);
-
-        if ($this->driver === Driver::sqlite) {
-            $this->pdo->query('PRAGMA foreign_keys = ON');
-        }
     }
 
     public function __invoke(Query $query): Sequence

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -9,7 +9,6 @@ namespace Formal\AccessLayer;
 enum Driver
 {
     case mysql;
-    case sqlite;
     case postgres;
 
     /**
@@ -21,7 +20,6 @@ enum Driver
     {
         return match ($this) {
             self::mysql => "`$name`",
-            self::sqlite => "\"$name\"",
             self::postgres => "\"$name\"",
         };
     }

--- a/src/Query/Delete.php
+++ b/src/Query/Delete.php
@@ -52,7 +52,12 @@ final class Delete implements Query
     {
         /** @var non-empty-string */
         return \sprintf(
-            'DELETE FROM %s %s',
+            'DELETE %s FROM %s %s',
+            match (true) {
+                $driver === Driver::postgres => '',
+                $this->table instanceof Name\Aliased => $driver->escapeName($this->table->alias()),
+                default => $this->table->sql($driver),
+            },
             $this->table->sql($driver),
             $this->where->sql($driver),
         );

--- a/src/Query/Delete.php
+++ b/src/Query/Delete.php
@@ -9,10 +9,7 @@ use Formal\AccessLayer\{
     Table\Name,
     Driver,
 };
-use Innmind\Specification\{
-    Specification,
-    Comparator\Property,
-};
+use Innmind\Specification\Specification;
 use Innmind\Immutable\{
     Sequence,
     Str,

--- a/src/Query/Select/Join.php
+++ b/src/Query/Select/Join.php
@@ -8,6 +8,7 @@ use Formal\AccessLayer\{
     Table\Column,
     Driver,
 };
+use Innmind\Immutable\Maybe;
 
 /**
  * @psalm-immutable
@@ -58,6 +59,17 @@ final class Join
     public function table(): Table\Name|Table\Name\Aliased
     {
         return $this->table;
+    }
+
+    /**
+     * @return Maybe<array{
+     *      Column\Name|Column\Name\Namespaced|Column\Name\Aliased,
+     *      Column\Name|Column\Name\Namespaced|Column\Name\Aliased,
+     * }>
+     */
+    public function condition(): Maybe
+    {
+        return Maybe::of($this->on);
     }
 
     /**

--- a/src/Query/Update.php
+++ b/src/Query/Update.php
@@ -5,6 +5,7 @@ namespace Formal\AccessLayer\Query;
 
 use Formal\AccessLayer\{
     Query,
+    Query\Select\Join,
     Table\Name,
     Row,
     Driver,
@@ -13,6 +14,7 @@ use Innmind\Specification\Specification;
 use Innmind\Immutable\{
     Sequence,
     Str,
+    Monoid\Concat,
 };
 
 /**

--- a/src/Query/Update.php
+++ b/src/Query/Update.php
@@ -5,7 +5,6 @@ namespace Formal\AccessLayer\Query;
 
 use Formal\AccessLayer\{
     Query,
-    Query\Select\Join,
     Table\Name,
     Row,
     Driver,
@@ -14,7 +13,6 @@ use Innmind\Specification\Specification;
 use Innmind\Immutable\{
     Sequence,
     Str,
-    Monoid\Concat,
 };
 
 /**

--- a/src/Query/Where.php
+++ b/src/Query/Where.php
@@ -112,7 +112,7 @@ final class Where
             return \sprintf('%s IS NULL', $column);
         }
 
-        $comparator = match ($specification->sign()) {
+        return match ($specification->sign()) {
             Sign::in => $this->buildInSql($driver, $specification),
             default => \sprintf(
                 '%s %s ?',
@@ -120,19 +120,6 @@ final class Where
                 $sign,
             ),
         };
-
-        if (
-            $driver === Driver::sqlite &&
-            \in_array(
-                $specification->sign(),
-                [Sign::startsWith, Sign::endsWith, Sign::contains],
-                true,
-            )
-        ) {
-            $comparator .= " ESCAPE '\\'";
-        }
-
-        return $comparator;
     }
 
     private function buildComposite(

--- a/src/Table/Column/Type.php
+++ b/src/Table/Column/Type.php
@@ -255,7 +255,6 @@ final class Type
             $this->nullable ? '' : 'NOT NULL',
             $this->buildDefault(),
             match (true) {
-                $driver === Driver::sqlite => '',
                 $driver === Driver::postgres => '',
                 \is_null($this->comment) => '',
                 default => "COMMENT '{$this->escape($this->comment)}'",


### PR DESCRIPTION
## Problem

When trying to update the ORM to version 3 of this package it revealed:
- deleting with an aliased table doesn't work
- joins when deleting are used by the ORM

## Solution

- Removes support for SQLite as it doesn't support table alias and joins when deleting
- Fix table aliasing when deleting
- Reintroduce `Delete::join()`